### PR TITLE
fix: Try error rangeError invalid typed array length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "11"
+  - "12"
 
 script:
   - npm run lint

--- a/lib/handle.js
+++ b/lib/handle.js
@@ -85,13 +85,13 @@ Handle.prototype._flow = function flow () {
   })
 
   this._stream.on('end', function () {
-    self.onread(uv.UV_EOF, Buffer.alloc(0))
+    self.onread(new Buffer(0))
   })
 
   this._stream.on('close', function () {
     setImmediate(function () {
       if (self._reading) {
-        self.onread(uv.UV_ECONNRESET, Buffer.alloc(0))
+        self.onread(new Buffer(0))
       }
     })
   })


### PR DESCRIPTION
Looking for bug fixes when using **SPDY** with version nodejs > 11

RangeError: Invalid typed array length: -104 at new Uint8Array (<anonymous>) at new FastBuffer (buffer.js:72:1)

Reference:
https://www.gitmemory.com/issue/spdy-http2/node-spdy/350/496787821