### PR TITLE
Fix support for node 11.1 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "11.1"
+  - "12"
 
 script:
   - npm run lint


### PR DESCRIPTION
Fixes #6 

Took a stab at trying to fix `onread` support for node 11.1 and above.
Looked at https://github.com/nodejs/node/blob/v11.1.0/lib/internal/stream_base_commons.js#L111 to figure out how to pass `nread`
Confirmed on master https://github.com/nodejs/node/blob/master/lib/internal/stream_base_commons.js#L163 that the implement hasn't changed since then

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spdy-http2/handle-thing/13)
<!-- Reviewable:end -->
