### PR TITLE
change readStop to private function

### DIFF
--- a/lib/handle.js
+++ b/lib/handle.js
@@ -85,11 +85,11 @@ Handle.prototype.readStart = function readStart () {
   return 0
 }
 
-Handle.prototype.readStop = function readStop () {
+Handle.prototype._readStop = function _readStop () {
   this._reading = false
 
   if (!this._stream) {
-    this.once('stream', this.readStop)
+    this.once('stream', this._readStop)
     return 0
   }
   this._stream.pause()
@@ -128,7 +128,7 @@ Handle.prototype._close = function _close () {
     }
   })
 
-  this.readStop()
+  this._readStop()
 }
 
 Handle.prototype.shutdown = function shutdown (req) {


### PR DESCRIPTION
To fix issue: https://github.com/spdy-http2/node-spdy/issues/369
Issue reproduce POC: https://github.com/hotyhuang/SSEexample

I found out that this issue with SSE is caused by recent commit in Nodejs: https://github.com/nodejs/node/commit/138eb32be1a912f1b8a551f657880f19c12f864c
I personally is not familiar with spdy code, just tried out this solution, and looks like it's working perfectly with node v10 ~ v12.